### PR TITLE
fix: prevent USB mount failure from formatting SD card

### DIFF
--- a/firmware/JcorpNomadProject/usb_mode.cpp
+++ b/firmware/JcorpNomadProject/usb_mode.cpp
@@ -84,7 +84,8 @@ void usb_setup() {
   Serial.println(">>> USB mode: mounting SD & starting MSC");
 
   SD_MMC.setPins(clk, cmd, d0, d1, d2, d3);
-  if (!SD_MMC.begin("/sdcard", false, true, 50000000)) {
+  // Never format user media when USB mode cannot mount it.
+  if (!SD_MMC.begin("/sdcard", false, false, 50000000)) {
     Serial.println("ERROR: SD card mount failed!");
     return;
   }


### PR DESCRIPTION
## Summary

- prevent USB Mass Storage mode from formatting an SD card when mounting fails
- retain the existing error return path so USB mode stops instead of altering user media

## Root cause

The third `SD_MMC.begin` argument is `format_if_mount_failed`. USB mode passed `true`, unlike normal media mode.

## Validation

- verified the bundled `SD_MMC.h` API declaration
- asserted the USB mount call disables `format_if_mount_failed`
- ran `git show --check`
